### PR TITLE
Support unicode characters in search terms.

### DIFF
--- a/GenericSearch.Grammar.Test/SearchExtensions_TestBase.cs
+++ b/GenericSearch.Grammar.Test/SearchExtensions_TestBase.cs
@@ -25,6 +25,15 @@ namespace GenericSearch.Grammar.Test
             }
             .AsQueryable();
 
+        private readonly IQueryable<Document> sampleInputSpecialCharacters = new[]
+            {
+                new Document() { Title = "oneü" },
+                new Document() { Title = "one twoü" },
+                new Document() { Title = "one two threeß" },
+                new Document() { Title = "one two three fourß" }
+            }
+         .AsQueryable();
+
         protected SearchExtensions_TestBase(Func<IQueryable<Document>, Expression<Func<Document, string>>, string, IQueryable<Document>> filter)
         {
             this.filter = filter;
@@ -58,6 +67,17 @@ namespace GenericSearch.Grammar.Test
         public void GetMatches_InvalidSearchTerm_ThrowsArgumentNullException()
         {
             var matches = this.filter(sampleInput, d => d.Title, "(Test and Test").ToArray();
+        }
+
+        [TestMethod]
+        public void GetMatches_SearchTermWithUmlaut_CorrectElementsReturned()
+        {
+            var matches = this.filter(sampleInputSpecialCharacters, d => d.Title, "ü").ToArray();
+
+            Assert.AreEqual(2, matches.Length);
+
+            matches = this.filter(sampleInputSpecialCharacters, d=> d.Title, "ß").ToArray();
+            Assert.AreEqual(2, matches.Length);
         }
 
         [TestMethod]

--- a/GenericSearch.Grammar/AntlrGrammar/SearchGrammar.g4
+++ b/GenericSearch.Grammar/AntlrGrammar/SearchGrammar.g4
@@ -32,4 +32,26 @@ parenthesizedExpression : '(' orExpression ')';
  * Lexer Rules
  */
 
-TERM :                    [a-zA-Z0-9$_]+;
+TERM :                   
+	(
+		[a-zA-Z0-9]
+		|
+		/*
+			matches characters considered Unicode letters.
+			taken from: http://www.uco.es/~ma1fegan/Comunes/manuales/pl/ANTLR/ANTLR-INGLES.pdf
+		*/
+		'\u0024' |
+		['\u0041-\u005a'] |
+		'\u005f' |
+		['\u0061-\u007a'] |
+		['\u00c0-\u00d6'] |
+		['\u00d8-\u00f6'] |
+		['\u00f8-\u00ff'] |
+		['\u0100-\u1fff'] |
+		['\u3040-\u318f'] |
+		['\u3300-\u337f'] |
+		['\u3400-\u3d2d'] |
+		['\u4e00-\u9fff'] |
+		['\uf900-\ufaff']
+	)+
+;


### PR DESCRIPTION
This PR adds support for unicode characters in search terms in the Antlr grammar. The unit test currently fails on for the Irony implementation. I suggest to remove that code path because it does not add any value over the Antlr parser.
